### PR TITLE
Fixed Error: Class 'Terminus\Models\Collections\Sites' not found

### DIFF
--- a/Commands/ComposerCommand.php
+++ b/Commands/ComposerCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace Terminus\Commands;
 
-use Terminus\Models\Collections\Sites;
+use Terminus\Collections\Sites;
 use Terminus\Models\Environment;
 
 /**


### PR DESCRIPTION
All Terminus\Models\Collections namespaces have been changed to Terminus\Collections:
https://github.com/pantheon-systems/terminus/releases/tag/0.13.0
