### PR TITLE
Call ssh command without buffering output with ob_start().

### DIFF
--- a/Commands/ComposerCommand.php
+++ b/Commands/ComposerCommand.php
@@ -71,8 +71,7 @@ class ComposerCommand extends CommandWithSSH {
     }
     $exit_code = $this->sendCommandViaUnbufferedSsh($environment, $command);
     if ($exit_code) {
-      $output = 'Unable to execute command.';
-      $this->log()->error($output);
+      $this->failure('Command failed with exit code ' . $exit_code);
     }
 
     $diff = $environment->diffstat();


### PR DESCRIPTION
The `terminus composer` command works much better if its output is not buffered with ob_start(), as Terminus does.