### PR TITLE
Fix link to installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ filesystem.
 
 
 ## Installation
-For help installing, see [Terminus's Wiki](https://github.com/pantheon-systems/terminus/wiki/Plugins)
+For help installing, see the [Terminus manual](https://pantheon.io/docs/terminus/plugins).
 
 ## Help
 Run `terminus help composer` for help.


### PR DESCRIPTION
Hello! The link to the Terminus wiki took me to a "start new page" option, rather than installation instructions. This link seems like the right one, but feel free to edit if you don't agree.